### PR TITLE
fix: correct isNextProject function to check for Next.js configuration

### DIFF
--- a/packages/notcms-kit/src/index.ts
+++ b/packages/notcms-kit/src/index.ts
@@ -76,7 +76,6 @@ async function init() {
 function isNextProject() {
   // js, ts, mjs, cjs
   const ext = [".js", ".ts", ".mjs", ".cjs"];
-  return true;
   return ext.some((e) =>
     existsSync(path.resolve(process.cwd(), `next.config${e}`))
   );


### PR DESCRIPTION
This pull request modifies the `isNextProject` function in the `packages/notcms-kit/src/index.ts` file to improve its accuracy in detecting Next.js projects.

* [`packages/notcms-kit/src/index.ts`](diffhunk://#diff-76be669e725358413d7fb00ef54c8f557673e1fa462a74310b77bd3d6aa26264L79): Changed the `isNextProject` function to check for the existence of `next.config` files with specific extensions instead of always returning `true`.

close #6 