### PR TITLE
chore: update CodeQL action to v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,3 @@
-# Reusable workflow for code analysis; to eject, you can replace this file with
-# https://github.com/ryansonshine/ryansonshine/blob/main/.github/workflows/codeql-analysis.yml
 name: "CodeQL"
 
 permissions:
@@ -18,4 +16,25 @@ on:
 
 jobs:
   analyze:
-    uses: ryansonshine/ryansonshine/.github/workflows/codeql-analysis.yml@main
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

- replace the external reusable CodeQL workflow with a repository-local job
- update CodeQL `init`, `autobuild`, and `analyze` actions from v2 to v3
- update `actions/checkout` to v5

## Why

The reusable workflow referenced from `ryansonshine/ryansonshine@main` still uses CodeQL Action v2. GitHub now reports v1 and v2 as deprecated, and the external branch reference prevents this repository from controlling the action versions it runs.

Defining the JavaScript analysis job locally removes that dependency and pins all CodeQL steps to the supported v3 major version.

## Validation

- `pnpm check`
- `git diff --check`
- confirmed no CodeQL Action v1/v2 references remain in `.github/workflows`
